### PR TITLE
Improve performance of code

### DIFF
--- a/SymbolDiff/Algorithms.cpp
+++ b/SymbolDiff/Algorithms.cpp
@@ -250,12 +250,12 @@ std::unique_ptr<ExpressionBase> Variable::Derivative(char wrt) const
 
 std::unique_ptr<ExpressionBase> OperatorPlus::Derivative(char wrt) const
 {
-    return std::make_unique<OperatorPlus>(*left->Derivative(wrt), *right->Derivative(wrt));
+    return std::make_unique<OperatorPlus>(left->Derivative(wrt).release(), right->Derivative(wrt).release());
 }
 
 std::unique_ptr<ExpressionBase> OperatorMinus::Derivative(char wrt) const
 {
-    return std::make_unique<OperatorMinus>(*left->Derivative(wrt), *right->Derivative(wrt));
+    return std::make_unique<OperatorMinus>(left->Derivative(wrt).release(), right->Derivative(wrt).release());
 }
 
 std::unique_ptr<ExpressionBase> OperatorMultiply::Derivative(char wrt) const

--- a/SymbolDiff/Benchmark.h
+++ b/SymbolDiff/Benchmark.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <chrono>
+#include <utility>
+
+template<typename F, typename... Args>
+double funcTime(F func, Args&&... args) 
+{
+	std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
+	func(std::forward<Args>(args)...);
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - t1).count();
+}
+
+template<typename F, typename... Args>
+double Benchmark(F func, int rep, Args&&... args)
+{
+	double total = 0;
+
+	for (int i = 0; i < rep; i++)
+	{
+		total += funcTime(func, std::forward<Args>(args)...);
+	}
+
+	return total / rep;
+}
+

--- a/SymbolDiff/Expression.cpp
+++ b/SymbolDiff/Expression.cpp
@@ -159,7 +159,7 @@ std::unique_ptr<ExpressionBase> OperatorPlus::Simplify(OperatorPlus expr)
 
 std::unique_ptr<ExpressionBase> OperatorMinus::Simplified() const
 {
-    auto copy = std::make_unique<OperatorMinus>(*left->Simplified(), *right->Simplified());
+    auto copy = std::make_unique<OperatorMinus>(left->Simplified().release(), right->Simplified().release());
 
     auto evaluated = copy->EvaluateIfPossible();
     if (evaluated) return evaluated;
@@ -169,7 +169,7 @@ std::unique_ptr<ExpressionBase> OperatorMinus::Simplified() const
 
 std::unique_ptr<ExpressionBase> OperatorDivide::Simplified() const
 {
-    auto copy = std::make_unique<OperatorDivide>(*left->Simplified(), *right->Simplified());
+    auto copy = std::make_unique<OperatorDivide>(left->Simplified().release(), right->Simplified().release());
 
     auto evaluated = copy->EvaluateIfPossible();
     if (evaluated) return evaluated;

--- a/SymbolDiff/Parser.cpp
+++ b/SymbolDiff/Parser.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<ExpressionBase> BuildExpression(std::vector<Token> input)
         // Close parenthesis
         else if (token->IsOperator() && token->GetOperator() == ')')
         {
-            ParseCloseParenthesis(nextIsUnary, operators, expressions, std::next(token) != input.end());
+            ParseCloseParenthesis(nextIsUnary, operators, expressions, std::next(token) == input.end());
         }
 
         // Other Operator
@@ -96,7 +96,7 @@ void ParseCloseParenthesis(bool& nextIsUnary, std::stack<std::string>& operators
 
     operators.pop();
 
-    if (operators.empty() && lastToken)
+    if (operators.empty() && !lastToken)
     {
         throw std::invalid_argument("Invalid expression: unbalanced parenthesis");
     }

--- a/SymbolDiff/SymbolDiff.vcxproj
+++ b/SymbolDiff/SymbolDiff.vcxproj
@@ -151,6 +151,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Algorithms.h" />
+    <ClInclude Include="Benchmark.h" />
     <ClInclude Include="Expression.h" />
     <ClInclude Include="Lexer.h" />
     <ClInclude Include="Parser.h" />

--- a/SymbolDiff/SymbolDiff.vcxproj.filters
+++ b/SymbolDiff/SymbolDiff.vcxproj.filters
@@ -44,5 +44,8 @@
     <ClInclude Include="Algorithms.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Benchmark.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/SymbolDiff/main.cpp
+++ b/SymbolDiff/main.cpp
@@ -1,8 +1,12 @@
-#include "Algorithms.h"
 #include <iostream>
+
+#include "Algorithms.h"
+#include "Benchmark.h"
 
 int main()
 {
+	//std::cout << "Benchmark: " << Benchmark(Differentiate, 100000, "(x+1)^2/(x-1)^2", 'x') << "ns\n";
+
 	std::string input;
 	
 	while (std::cout << "> f (x) = ", std::getline(std::cin, input))

--- a/SymbolDiff/main.cpp
+++ b/SymbolDiff/main.cpp
@@ -5,7 +5,7 @@
 
 int main()
 {
-	//std::cout << "Benchmark: " << Benchmark(Differentiate, 100000, "(x+1)^2/(x-1)^2", 'x') << "ns\n";
+	std::cout << "Benchmark: " << Benchmark(Differentiate, 100000, "(x+1)^2/(x-1)^2", 'x') << "ns\n";
 
 	std::string input;
 	


### PR DESCRIPTION
Added benchmarking code that averages 100k calls to Differentiate("(x+1)^2/(x-1)^2", 'x'). 

Before: 51700.6ns
After: 41789.8ns 

This is a performance improvement of ~24%.

The performance improvements come from avoiding unnecessary copies when expression objects could instead take ownership of pointers.